### PR TITLE
Remove `UIScrollViewDelegate` conformation from `VAAdCellProvider` 

### DIFF
--- a/VMFiveAdNetwork/VMFiveAdNetwork/VAAdCellProvider.h
+++ b/VMFiveAdNetwork/VMFiveAdNetwork/VAAdCellProvider.h
@@ -50,7 +50,7 @@ NSUInteger const kVAAdCellProviderAdOffsetInsertOnlyOne;
  
  
  */
-@interface VAAdCellProvider : NSObject <UITableViewDelegate, UITableViewDataSource, UIScrollViewDelegate>
+@interface VAAdCellProvider : NSObject <UITableViewDelegate, UITableViewDataSource>
 
 /** @name Properties */
 @property (nonatomic, strong, nonnull) NSString *placement; ///< Placement name for ads


### PR DESCRIPTION
Since `UITableViewDelegate` conformation has been added, no need to conform `UIScrollViewDelegate`.
